### PR TITLE
Put current coroutine in sleep on failed locking

### DIFF
--- a/src/runtime/processor.rs
+++ b/src/runtime/processor.rs
@@ -326,7 +326,7 @@ impl Processor {
             None => {},
             Some(coro_ptr) => unsafe {
                 self.set_last_result(Ok(State::Blocked));
-                (&mut *coro_ptr).yield_to(&*self.main_coro);
+                (&mut *coro_ptr).yield_to(&*self.main_coro)
             }
         }
     }

--- a/src/runtime/processor.rs
+++ b/src/runtime/processor.rs
@@ -326,7 +326,7 @@ impl Processor {
             None => {},
             Some(coro_ptr) => unsafe {
                 self.set_last_result(Ok(State::Blocked));
-                (&mut *coro_ptr).yield_to(&*self.main_coro)
+                (&mut *coro_ptr).yield_to(&*self.main_coro);
             }
         }
     }

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -40,7 +40,7 @@ struct WaitList {
 impl WaitList {
     fn new() -> WaitList {
         WaitList {
-            inner: VecDeque::new(),
+            inner: VecDeque::with_capacity(64),
         }
     }
 

--- a/src/sync/mpsc.rs
+++ b/src/sync/mpsc.rs
@@ -67,7 +67,7 @@ impl<T> Receiver<T> {
                 Err(TryRecvError::Disconnected) => return Err(RecvError),
             }
 
-            unsafe { &mut *self.wait_list.get() }.sleep();
+            unsafe { &mut *self.wait_list.get() }.push().block();
         }
     }
 }


### PR DESCRIPTION
Refactoring over mutex and mpsc channel implementation.

The new mutex implementation blocks the current coroutine if unable to acquire lock for SPIN_COUNT times (by default 32), which saves some CPU.

The same thing has been done for mpsc Receiver.

Resolves #2 for me.

I'm open for discussing.