### PR TITLE
use customized panic handle

### DIFF
--- a/src/coroutine.rs
+++ b/src/coroutine.rs
@@ -60,6 +60,7 @@ pub struct Coroutine {
     preferred_processor: Option<WeakProcessor>,
     state: State,
     runnable: Option<Box<FnBox()>>,
+    name: Option<String>,
 }
 
 unsafe impl Send for Coroutine {}
@@ -72,11 +73,16 @@ impl Coroutine {
             preferred_processor: None,
             state: State::Initialized,
             runnable: runnable,
+            name: None,
         })
     }
 
     pub unsafe fn empty() -> Handle {
         Coroutine::new(Context::empty(), None, None)
+    }
+
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_ref().map(|x| &x[..])
     }
 
     pub fn spawn_opts(f: Box<FnBox()>, opts: Options) -> Handle {
@@ -85,6 +91,7 @@ impl Coroutine {
         });
 
         let mut coro = Coroutine::new(Context::empty(), Some(stack), Some(f));
+        coro.name = opts.name;
         let coro_ptr: *mut Coroutine = &mut *coro as *mut Coroutine;
         let stack_ptr: *mut Stack = coro.stack.as_mut().unwrap();
         coro.context.init_with(coroutine_initialize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 
 //! Coroutine scheduling with asynchronous I/O support
 
-#![feature(recover, std_panic, reflect_marker, fnbox)]
+#![feature(recover, std_panic, reflect_marker, fnbox, panic_handler)]
 
 #[macro_use]
 extern crate log;

--- a/src/runtime/processor.rs
+++ b/src/runtime/processor.rs
@@ -181,6 +181,11 @@ impl Processor {
         PROCESSOR.with(|proc_opt| unsafe { (&mut *proc_opt.get()).as_mut() })
     }
 
+    /// Get the current running coroutine
+    pub fn current_coroutine(&self) -> Option<&Coroutine> {
+        self.current_coro.as_ref().map(|x| &**x)
+    }
+
     /// Obtains the currently running coroutine after setting it's state to Blocked.
     /// NOTE: DO NOT call any Scheduler or Processor method within the passed callback, other than ready().
     pub fn take_current_coroutine<U, F>(&mut self, f: F) -> U


### PR DESCRIPTION
Use `std::panic` to set a customized handle to ignore force unwinding and prints customized panic message.

Possible problem:

1. If someone uses a library that sets another customized handler to handle panics, what would happen?