### PR TITLE
Readme: Limitations section

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,16 @@ fn main() {
 }
 ```
 
+## Limitations (due to [context-rs](https://github.com/zonyitoo/context-rs))
+
+* Stack size per coroutine is limited (128 KiB by default). You can change this
+  limit by using `coio::spawn_opts` or custom `coio::Builder`. A protected page
+  is kept at the end of the stack in order to trigger a "Segmentation fault" on
+  stack overflow. This is not much of a problem because you'll rarely hit this
+  limit unless you have a really deep recursive call, or try to allocate a very
+  large slice entirely in stack. (Converting recursive logic into iterative
+  code is considered a good practice which libraries usually follow.)
+
 ## Basic Benchmarks
 
 See `benchmarks` for more details.


### PR DESCRIPTION
The reasons behind this limitation ([that you mentioned](https://github.com/zonyitoo/coio-rs/issues/30#issuecomment-177399808)) and further details (possibility of over-stepping the protected page) could be included in the `context-rs` repository.