### PR TITLE
Migrate to context 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,20 @@
+sudo: false
 language: rust
-rust: nightly
+rust:
+    - nightly
+
+os:
+    - linux
+    - osx
+
+env:
+    - RUST_BACKTRACE=1
 
 script:
-    - RUST_BACKTRACE=1 cargo test -v
-    - cargo build --manifest-path benchmarks/Cargo.toml -v
-    - RUST_BACKTRACE=1 cargo run --example simple
-    - RUST_BACKTRACE=1 cargo run --example panic
-    - RUST_BACKTRACE=1 cargo test -v --release
-    - RUST_BACKTRACE=1 cargo run --example simple --release
-    - RUST_BACKTRACE=1 cargo run --example panic --release
+    - cargo test
+    - cargo build --manifest-path benchmarks/Cargo.toml
+    - cargo run --example simple
+    - cargo run --example panic
+    - cargo test --release
+    - cargo run --example simple --release
+    - cargo run --example panic --release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,17 +10,14 @@ keywords = ["coroutine", "fiber", "green", "green thread", "non-blocking", "io",
 name = "coio"
 
 [dev-dependencies]
-clap = "*"
-env_logger = "*"
-num_cpus = "*"
-rand = "*"
-time = "*"
+clap = "2.1"
+env_logger = "0.3"
+num_cpus = "0.2"
+time = "0.1"
 
 [dependencies]
-chrono = "^0.2.15"
-context = { git = "https://github.com/zonyitoo/context-rs.git" }
-deque = "^0.3.1"
-libc = "^0.1.10"
-log = "^0.3.1"
-mio = "^0.5.0"
-rand = "^0.3.10"
+context = "1.0"
+deque = "0.3"
+log = "0.3"
+mio = "0.5"
+rand = "0.3"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+environment:
+  RUST_BACKTRACE: 1
+  matrix:
+      - TARGET: x86_64-pc-windows-gnu
+        MSYS2_BITS: 64
+      - TARGET: i686-pc-windows-gnu
+        MSYS2_BITS: 32
+      - TARGET: x86_64-pc-windows-msvc
+      - TARGET: i686-pc-windows-msvc
+install:
+  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe"
+  - rust-nightly-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
+  - SET PATH=%PATH%;C:\Program Files (x86)\Rust\bin
+  - if defined MSYS2_BITS set PATH=%PATH%;C:\msys64\mingw%MSYS2_BITS%\bin
+  - rustc -V
+  - cargo -V
+
+build: false
+
+test_script:
+  - cargo test

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,8 +1,11 @@
 extern crate coio;
+extern crate env_logger;
 
 use coio::Scheduler;
 
 fn main() {
+    env_logger::init().unwrap();
+    
     Scheduler::new()
         .run(|| {
             for _ in 0..10 {

--- a/src/options.rs
+++ b/src/options.rs
@@ -24,6 +24,7 @@
 use std::default::Default;
 
 /// Coroutine options
+#[derive(Debug, Clone)]
 pub struct Options {
     pub stack_size: usize,
     pub name: Option<String>,
@@ -40,12 +41,12 @@ impl Options {
         }
     }
 
-    pub fn stack_size(mut self, size: usize) -> Options {
+    pub fn stack_size(&mut self, size: usize) -> &mut Options {
         self.stack_size = size;
         self
     }
 
-    pub fn name(mut self, name: String) -> Options {
+    pub fn name(&mut self, name: String) -> &mut Options {
         self.name = Some(name);
         self
     }


### PR DESCRIPTION
## Todo

* [x] Basic resume and yield facilities

* [x] `block_with` mechanism

* [x] ~~Move the callback function of `Coroutine` onto its own stack.~~ FnBox() Is being used for now since `alloca()` is hard and generics lead to code bloat.

* [x] Move the `block_with` callback out of its stack

* [x] Test on major platforms (x86, x86_64 / Linux, OS X, Windows (MSVC, MinGW32, Cygwin)) - **NOTE:** Is this necessary though? We might want to verify the functionality of context-rs instead.

* [x] Test with Valgrind to fix #15 

* [x] Cannot run on Linux x86. It crashes when the `callback()` in `coroutine_initialize` returns.

* [x] Squash all commits before merging? Yes/No? (optionally)

Issue: #40